### PR TITLE
Remove redundant folder

### DIFF
--- a/Dockerfiles/WebAPI.heroku.dockerfile
+++ b/Dockerfiles/WebAPI.heroku.dockerfile
@@ -16,8 +16,8 @@ RUN dotnet publish -o publish/ -c Release --no-build --nologo src/WebAPI/
 # Use single ASP.NET Core runtime to reduce image size.
 FROM mcr.microsoft.com/dotnet/aspnet:5.0
 WORKDIR /app
-COPY --from=sdk app/publish/ publish/
+COPY --from=sdk app/publish/ .
 
 # Run WebAPI.
 # Using CMD instead of ENTRYPOINT and such ASPNETCORE_URLS requested from Heroku Dyno.
-CMD ASPNETCORE_URLS=http://*:$PORT dotnet publish/WebAPI.dll
+CMD ASPNETCORE_URLS='http://*:$PORT' dotnet WebAPI.dll


### PR DESCRIPTION
Когда файл appsettings.json находится во вложенной папке ASP.NET Core
не удаётся её обнаружить. Это привожит к тому, что становятся приложение
не может использовать ключи.

See also: #17